### PR TITLE
Make `svg_fmt` dependency optional

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,11 +12,12 @@ keywords = ["2d", "graphics"]
 [features]
 checks = []
 serialization = ["serde", "euclid/serde"]
+svg = ["svg_fmt"]
 
 [dependencies]
 euclid = "0.19.5"
 serde = { version = "1.0", optional = true, features = ["serde_derive"] }
-svg_fmt = "0.2.0"
+svg_fmt = { version = "0.2.0", optional = true }
 
 [workspace]
 members = ["cli", "ffi"]

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -14,7 +14,7 @@ path = "src/main.rs"
 checks = ["guillotiere/checks"]
 
 [dependencies]
-guillotiere = { path = "../", features = ["serialization"] }
+guillotiere = { path = "../", features = ["serialization", "svg"] }
 serde = { version = "1.0", features = ["serde_derive"] }
 ron = "0.4.2"
 clap = "2.32"

--- a/src/allocator.rs
+++ b/src/allocator.rs
@@ -1409,6 +1409,7 @@ pub struct ChangeList {
     pub failures: Vec<Allocation>,
 }
 
+#[cfg(feature = "svg_fmt")]
 pub fn dump_svg(atlas: &AtlasAllocator, output: &mut dyn std::io::Write) -> std::io::Result<()> {
     use svg_fmt::*;
 


### PR DESCRIPTION
Hey, thanks for this nice library!

We are planning to use it in `iced_wgpu` to generate image atlases: https://github.com/hecrj/iced/pull/154

I noticed the `svg_fmt` dependency is only used in the `dump_svg` function, which seems to satisfy a very specific use case. This PR makes this dependency optional.