### PR TITLE
Use unique ids in the recording allocator

### DIFF
--- a/src/allocator.rs
+++ b/src/allocator.rs
@@ -43,7 +43,7 @@ impl AllocIndex {
 #[repr(C)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
-pub struct AllocId(u32);
+pub struct AllocId(pub(crate) u32);
 
 impl AllocId {
     pub(crate) fn to_u32(&self) -> u32 {


### PR DESCRIPTION
This should allow simplifying a few things in the recording infrastructure.