### PR TITLE
Fix the "grow" method for the `SimpleAllocator`.

### DIFF
--- a/src/allocator.rs
+++ b/src/allocator.rs
@@ -1319,6 +1319,8 @@ impl SimpleAtlasAllocator {
         let (split_rect, leftover_rect, _) =
             guillotine_rect(&new_size.into(), self.size, Orientation::Vertical);
 
+        self.size = new_size;
+
         self.add_free_rect(&split_rect);
         self.add_free_rect(&leftover_rect);
     }


### PR DESCRIPTION
We hadn't run into this issue before because we never tried to grow our texture atlas (presumably nobody else had, either!).