### PR TITLE
Avoid integer overflows when computing rectangle areas

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "guillotiere"
-version = "0.6.1"
+version = "0.6.2"
 authors = ["Nicolas Silva <nical@fastmail.com>"]
 edition = "2018"
 license = "MIT/Apache-2.0"


### PR DESCRIPTION
In some places the area calculation can be avoided, in other places we can do an overflow check with a default value as the results are used to guide heuristics and don't need to be exact.

Fixes #25.