### PR TITLE
Update workflow branch name

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,9 +2,9 @@ name: Rust
 
 on:
   push:
-    branches: [ master ]
+    branches: [ main ]
   pull_request:
-    branches: [ master ]
+    branches: [ main ]
 
 jobs:
   ci:


### PR DESCRIPTION
I noticed after updating the build status badges in #34 that test builds did not appear to be running. It looks like updating the branch name fixes that.